### PR TITLE
Add draw_text method to Detextifier class

### DIFF
--- a/-1,3
+++ b/-1,3
@@ -1,0 +1,27 @@
+import cv2
+from detextify.text_detector import TextDetector
+
+
+class Detextifier:
+    def __init__(self, text_detector: TextDetector, inpainter: Inpainter):
+        self.text_detector = text_detector
+        self.inpainter = inpainter
+
+    def detextify(self, in_image_path: str, out_image_path: str, prompt=Inpainter.DEFAULT_PROMPT, max_retries=5):
+        to_inpaint_path = in_image_path
+        for i in range(max_retries):
+            print(f"Iteration {i} of {max_retries} for image {in_image_path}:")
+
+            print(f"\tCalling text detector...")
+            text_boxes = self.text_detector.detect_text(to_inpaint_path)
+            print(f"\tDetected {len(text_boxes)} text boxes.")
+
+            if not text_boxes:
+                break
+
+            print(f"\tCalling in-painting model...")
+            self.inpainter.inpaint(to_inpaint_path, text_boxes, prompt, out_image_path)
+            import os
+            assert os.path.exists(out_image_path)
+            to_inpaint_path = out_image_path
+

--- a/-1,4
+++ b/-1,4
@@ -1,5 +1,6 @@
-from detextify.inpainter import Inpainter
+import cv2
 from detextify.text_detector import TextDetector
+from detextify.utils import draw_text_box
 
 
 class Detextifier:

--- a/-27,3
+++ b/-27,3
@@ -1,0 +1,38 @@
+from detextify.inpainter import Inpainter
+from detextify.text_detector import TextDetector
+
+
+class Detextifier:
+    def __init__(self, text_detector: TextDetector, inpainter: Inpainter):
+        self.text_detector = text_detector
+        self.inpainter = inpainter
+
+    def detextify(self, in_image_path: str, out_image_path: str, prompt=Inpainter.DEFAULT_PROMPT, max_retries=5):
+        to_inpaint_path = in_image_path
+        for i in range(max_retries):
+            print(f"Iteration {i} of {max_retries} for image {in_image_path}:")
+
+            print(f"\tCalling text detector...")
+            text_boxes = self.text_detector.detect_text(to_inpaint_path)
+            print(f"\tDetected {len(text_boxes)} text boxes.")
+
+            if not text_boxes:
+                break
+
+            print(f"\tCalling in-painting model...")
+            self.inpainter.inpaint(to_inpaint_path, text_boxes, prompt, out_image_path)
+            import os
+            assert os.path.exists(out_image_path)
+            to_inpaint_path = out_image_path
+    def detextify(self, in_image_path: str, out_image_path: str, prompt=Inpainter.DEFAULT_PROMPT, max_retries=5):
+        ...
+
+    def draw_text(self, in_image_path: str, out_image_path: str, text: str, text_boxes: List[TextBox], color=(0, 0, 255)):
+        """Draws the given text into the given text boxes on the given image."""
+        # Load the image
+        image = cv2.imread(in_image_path)
+        # Draw the text into each text box
+        for tb in text_boxes:
+            cv2.putText(image, text, (tb.x, tb.y), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
+        # Save the image
+        cv2.imwrite(out_image_path, image)


### PR DESCRIPTION
This pull request adds a method to the Detextifier class to draw text into a TextBox on an image.

The changes are as follows:

* detextify/detextifier.py:
  * Imported the `cv2` library
  * Added the `draw_text` method to the `Detextifier` class:
    ```
    def draw_text(self, in_image_path: str, out_image_path: str, text: str, text_boxes: List[TextBox], color=(0, 0, 255)):
        """Draws the given text into the given text boxes on the given image."""
        # Load the image
        image = cv2.imread(in_image_path)
        # Draw the text into each text box
        for tb in text_boxes:
            cv2.putText(image, text, (tb.x, tb.y), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1)
        # Save the image
        cv2.imwrite(out_image_path, image)
    ```
  * Imported the `draw_text_box` method from `detextify/utils.py` into `detextify/detextifier.py`